### PR TITLE
Fix crt-yo6-KV-M1420B-fast and barrel-distortion

### DIFF
--- a/crt-yo6-KV-M1420B-fast.glslp
+++ b/crt-yo6-KV-M1420B-fast.glslp
@@ -14,7 +14,7 @@ scale_type1 = "absolute"
 scale_x1 = 1684
 scale_y1 = 1329
 
-shader2 = "../stock.glsl"
+shader2 = "stock.glsl"
 filter_linear2 = true
 
 textures = TEX_CRT

--- a/shaders/barrel-distortion.glsl
+++ b/shaders/barrel-distortion.glsl
@@ -35,10 +35,10 @@
 #endif
 
 uniform COMPAT_PRECISION mat4 MVPMatrix;
-COMPAT_ATTRIBUTE mediump vec4 VertexCoord;
-COMPAT_ATTRIBUTE mediump vec2 TexCoord;
+COMPAT_ATTRIBUTE COMPAT_PRECISION vec4 VertexCoord;
+COMPAT_ATTRIBUTE COMPAT_PRECISION vec2 TexCoord;
 
-COMPAT_VARYING mediump vec2 TEX0;
+COMPAT_VARYING COMPAT_PRECISION vec2 TEX0;
 
 void main()
 {
@@ -71,10 +71,10 @@ precision mediump float;
 uniform sampler2D Texture;
 uniform COMPAT_PRECISION vec2 InputSize;
 uniform COMPAT_PRECISION vec2 TextureSize;
-varying vec2 TEX0;
+COMPAT_VARYING vec2 TEX0;
 
-const mediump float BARREL_DISTORTION = 0.25;
-const mediump float rescale = 1.0 - (0.25 * BARREL_DISTORTION);
+const COMPAT_PRECISION float BARREL_DISTORTION = 0.25;
+const COMPAT_PRECISION float rescale = 1.0 - (0.25 * BARREL_DISTORTION);
 
 void main()
 {


### PR DESCRIPTION
- crt-yo6-KV-M1420B-fast and barrel-distortion are not working with gl2 targets.
- crt-yo6-KV-M1420B-fast has a wrong path for stock shader.
- barrel-distortion needs COMPAT_PRECISION and COMPAT_VARYING compatibility flags.